### PR TITLE
Issue 13: split string on commas

### DIFF
--- a/tests/Graphite/GraphBuilderTest.php
+++ b/tests/Graphite/GraphBuilderTest.php
@@ -153,7 +153,19 @@ class Graphite_GraphBuilderTest extends PHPUnit_Framework_TestCase {
 
     $g->ini($this->iniPath('test_bool_param_unset2.ini'));
     $this->assertEquals('', (string) $g);
-  } //end testBoolParamUnset
+  } //end test_bool_param_unset
+
+  public function test_ini_multiarg_array () {
+    $g = Graphite_GraphBuilder::builder()
+        ->ini($this->iniPath('test_multiarg_array.ini'));
+    $this->assertEquals('target=aliasByNode(my-metric,1,3,5)', (string) $g);
+  } //end test_ini_multiarg_array
+
+  public function test_ini_multiarg_split () {
+    $g = Graphite_GraphBuilder::builder()
+        ->ini($this->iniPath('test_multiarg_split.ini'));
+    $this->assertEquals("target=aliasByNode(my-metric,1,3,5)&target=aliasSub(ip.*TCP*,'%5E.*TCP(%5Cd%2B)','%5C1')", (string) $g);
+  } //end test_ini_multiarg_split
 
 
   /**

--- a/tests/Graphite/test_multiarg_array.ini
+++ b/tests/Graphite/test_multiarg_array.ini
@@ -1,0 +1,4 @@
+[my-metric]
+aliasbynode[] = 1
+aliasbynode[] = 3
+aliasbynode[] = 5

--- a/tests/Graphite/test_multiarg_split.ini
+++ b/tests/Graphite/test_multiarg_split.ini
@@ -1,0 +1,6 @@
+[my-metric]
+aliasbynode = "1,3, 5"
+
+[fancy]
+metric = "ip.*TCP*"
+aliasSub = "'^.*TCP(\d+)', '\1'"


### PR DESCRIPTION
When the function takes multiple args and a single arg is given and this arg is
a string, try splitting the arg on commas to get a list of args. If that list
has more than one element, strip whitespace from all the elements and use this
new list as the call argument list.

Also fixed a problem where strings may become double quoted if the caller has
tried to be helpful and pre-quoted the string.
