### PR TITLE
Issue #19: Generator support

### DIFF
--- a/examples/cpu_irq.ini
+++ b/examples/cpu_irq.ini
@@ -50,4 +50,4 @@ prefix = ^puppet.time
 metric = total
 color = blue
 alias = Puppet Run
-line = 1
+impulse = 1

--- a/src/Graphite/Graph/Functions.php
+++ b/src/Graphite/Graph/Functions.php
@@ -53,7 +53,6 @@ class Graphite_Graph_Functions {
       'diffSeries'                 => array('-*', 50, 0),
       'divideSeries'               => array('-', 50, 0),
       'drawAsInfinite'             => array(null, 50, 0),
-      'events'                     => array('"*', 1, 0),
       'exclude'                    => array('"', 50, 0),
       'group'                      => array('-*', 50, 0),
       'groupByNode'                => array(array('#', '"'), 50, 1),
@@ -109,53 +108,32 @@ class Graphite_Graph_Functions {
 
 
   /**
-   * Data generation function.
-   *
-   * These are similar to the normal manipulation functions but differ in that
-   * they generate a base series rather than manipulating an existing series
-   * or combination of series.
-   *
-   * @var array
-   */
-  static protected $generators = array(
-      'constantLine'       => array('#', 1, false),
-      'randomWalkFunction' => array('"', 1, false),
-      'sinFunction'        => array(array('"', '-?'), 1, false),
-      'threshold'          => array(array('#', '"?', '"?'), 1, true),
-      'timeFunction'       => array('"', 1, false),
-    );
-
-
-  /**
    * Function name aliases.
    *
    * @param array
    */
   static protected $aliases = array(
-      'avg'        => 'averageSeries',
-      'cacti'      => 'cactiStyle',
-      'centile'    => 'nPercentile',
-      'counter'    => 'nonNegativeDerivative',
-      'impulse'    => 'drawAsInfinite',
-      'line'       => 'drawAsInfinite',
-      'max'        => 'maxSeries',
-      'min'        => 'minSeries',
-      'null'       => 'transformNull',
-      'randomWalk' => 'randomWalkFunction',
-      'sin'        => 'sinFunction',
-      'sum'        => 'sumSeries',
-      'time'       => 'timeFunction',
+      'avg'     => 'averageSeries',
+      'cacti'   => 'cactiStyle',
+      'centile' => 'nPercentile',
+      'counter' => 'nonNegativeDerivative',
+      'impulse' => 'drawAsInfinite',
+      'inf'     => 'drawAsInfinite',
+      'max'     => 'maxSeries',
+      'min'     => 'minSeries',
+      'null'    => 'transformNull',
+      'sum'     => 'sumSeries',
     );
 
 
   /**
-   * Find the canonical name for a target.
+   * Find the canonical name for a function.
    *
    * The value may be an alias or it may differ in case from the true
-   * target name.
+   * function name.
    *
-   * @param string $name Target to lookup
-   * @return string Proper name of target or false if not found
+   * @param string $name Function to lookup
+   * @return string Proper name of function or false if not found
    */
   static public function canonicalName ($name) {
     static $lookupMap;

--- a/src/Graphite/Graph/Generators.php
+++ b/src/Graphite/Graph/Generators.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @package Graphite
+ * @subpackage Graph
+ * @author Bryan Davis <bd808@bd808.com>
+ * @copyright 2011 Bryan Davis and contributors. All Rights Reserved.
+ * @license http://www.opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+/**
+ * Utility for target generators.
+ *
+ * Generators produce source data for a series.
+ *
+ * @package Graphite
+ * @subpackage Graph
+ * @author Bryan Davis <bd808@bd808.com>
+ * @copyright 2012 Bryan Davis and contributors. All Rights Reserved.
+ * @license http://www.opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ * @link http://readthedocs.org/docs/graphite/en/latest/functions.html
+ */
+class Graphite_Graph_Generators {
+
+  /**
+   * Data generation functions.
+   *
+   * These are similar to the normal manipulation functions but differ in that
+   * they generate a base series rather than manipulating an existing series
+   * or combination of series.
+   *
+   * @var array
+   */
+  static protected $generators = array(
+      'constantLine'       => array('#', 1, 0),
+      'events'             => array('"*', 1, 0),
+      'randomWalkFunction' => array('"', 1, 1),
+      'sinFunction'        => array(array('"', '-?'), 1, 1),
+      'threshold'          => array(array('#', '"?', '"?'), 1, 1),
+      'timeFunction'       => array('"', 1, 1),
+    );
+
+
+  /**
+   * Function name aliases.
+   *
+   * @param array
+   */
+  static protected $aliases = array(
+      'line'       => 'constantLine',
+      'random'     => 'randomWalkFunction',
+      'randomWalk' => 'randomWalkFunction',
+      'sin'        => 'sinFunction',
+      'sum'        => 'sumSeries',
+      'time'       => 'timeFunction',
+    );
+
+
+  /**
+   * Find the canonical name for a generator.
+   *
+   * The value may be an alias or it may differ in case from the true
+   * name.
+   *
+   * @param string $name Generator to lookup
+   * @return string Proper name of generator or false if not found
+   */
+  static public function canonicalName ($name) {
+    static $lookupMap;
+    if (null == $lookupMap) {
+      // lazily construct the lookup map
+      $tmp = array();
+      foreach (self::$generators as $func => $conf) {
+        $tmp[mb_strtolower($func)] = $func;
+      }
+      foreach (self::$aliases as $alias => $func) {
+        $tmp[mb_strtolower($alias)] = $func;
+      }
+      $lookupMap = $tmp;
+    }
+
+    // convert to lowercase and strip "delimiter" characters
+    $name = strtr(mb_strtolower($name), '_.-', '');
+    if (array_key_exists($name, $lookupMap)) {
+      return $lookupMap[$name];
+    } else {
+      return false;
+    }
+  } //end canonicalName
+
+
+  /**
+   * Get the call specification for a generator.
+   *
+   * @param string $name Generator name
+   * @return Graphite_Graph_CallSpec Function specification or null if not
+   *    found
+   */
+  static public function callSpec ($name) {
+    $name = self::canonicalName($name);
+    if (false === $name) {
+      return null;
+    }
+    $spec = self::$generators[$name];
+    return new Graphite_Graph_CallSpec(
+        $name, $spec[0], $spec[1], $spec[2], true);
+  }
+
+
+  /**
+   * Construction disallowed.
+   */
+  private function __construct () {
+    // no-op
+  }
+
+} //end Graphite_Graph_Generators

--- a/tests/Graphite/Graph/SeriesTest.php
+++ b/tests/Graphite/Graph/SeriesTest.php
@@ -41,4 +41,25 @@ class Graphite_Graph_SeriesTest extends PHPUnit_Framework_TestCase {
         Graphite_Graph_Series::generate($spec));
   }
 
+  /**
+   * Given: a generator call with no arguments
+   * Expect: a series using the generator with the alias as the only arg
+   */
+  public function test_generator_no_args () {
+    $b = Graphite_Graph_Series::builder()
+        ->random()
+        ->alias('Noise');
+    $this->assertEquals("randomWalkFunction('Noise')", $b->build());
+  }
+
+  /**
+   * Given: a generator call with arguments
+   * Expect: a series using the generator
+   */
+  public function test_generator_with_args () {
+    $b = Graphite_Graph_Series::builder()
+        ->threshold(123.456, "omgwtfbbq", "red");
+    $this->assertEquals("threshold(123.456,'omgwtfbbq','red')", $b->build());
+  }
+
 } //end Graphite_Graph_SeriesTest

--- a/tests/Graphite/GraphBuilderTest.php
+++ b/tests/Graphite/GraphBuilderTest.php
@@ -188,6 +188,16 @@ class Graphite_GraphBuilderTest extends PHPUnit_Framework_TestCase {
   } //end test_inherit
 
   /**
+   * Given: ini config using generators
+   * Expect: targets using generators a a primary data source
+   */
+  public function test_generator () {
+    $g = Graphite_GraphBuilder::builder()
+        ->ini($this->iniPath('test_generator.ini'));
+    $this->assertEquals("target=alias(constantLine(123.456),'Constantline')&target=timeFunction('The.time.series')&target=randomWalkFunction('Random')&target=sinFunction('this.is.the.sin',2)&target=threshold(15,'omgwtfbbq','red')&target=alias(events('*'),'Events')", (string) $g);
+  }
+
+  /**
    * Get the path to an ini file.
    * @param string $file File name
    * @return string Path to file

--- a/tests/Graphite/test_generator.ini
+++ b/tests/Graphite/test_generator.ini
@@ -1,0 +1,25 @@
+[constantline]
+:generator = "constantline"
+constantline = 123.456
+
+[time]
+:generator = "time"
+time = "The.time.series"
+
+[random]
+:generator = "random"
+; implicit argument of alias
+
+[sin]
+:generator = "sin"
+sin = "this.is.the.sin, 2"
+
+[threshold]
+:generator = "threshold"
+threshold[] = 15
+threshold[] = "omgwtfbbq"
+threshold[] = "red"
+
+[events]
+:generator = "events"
+events = "*"

--- a/tests/Graphite/test_ini_load.ini
+++ b/tests/Graphite/test_ini_load.ini
@@ -46,4 +46,4 @@ prefix = "^puppet.time"
 metric = total
 color = blue
 alias = Puppet Run
-line = 1
+inf = 1


### PR DESCRIPTION
Added support for generator style Graphite functions. These are functions that
can be used in place of a whisper metric to create graphable data. The most
commonly useful generators are `constantLine`, `threshold` and `events`.
`sinFunction`, `timeFunction` and `randomWalkFunction` can be useful for
debugging.
- Extracted generator metadata into its own class.
- Enhanced Graphite_Graph_CallSpec to understand generators.
- Enhanced Graphite_Graph_Series to understand generators.
- Added ini and DSL tests for new functionality.
