### PR TITLE
Issue #20: ini syntax for grouping series

### DIFF
--- a/src/Graphite/Graph/IniHelper.php
+++ b/src/Graphite/Graph/IniHelper.php
@@ -179,6 +179,33 @@ class Graphite_Graph_IniHelper {
         $conf = $this->extendSeries($parent, $conf);
       }
 
+      $group = self::pop($conf, ':series');
+      if (null !== $group) {
+        if (is_scalar($group)) {
+          $group = array_map('trim', explode(',', $group));
+        }
+        $conf['series'] = array();
+        foreach ($group as $name) {
+          // lookup the grouped series
+          $series = $this->findSeries($name);
+
+          // enable prefix if specified
+          $prefix = self::pop($series, ':prefix');
+          if (null !== $prefix) {
+            $this->builder->prefix($this->builder->lookupPrefix($prefix));
+          }
+
+          // augment the series with graph defaults and store
+          $conf['series'][] = $this->builder->addSeriesDefaults(
+              $name, $series);
+
+          // restore prefix
+          if (null !== $prefix) {
+            $this->builder->endPrefix();
+          }
+        }
+      }
+
       $prefix = self::pop($conf, ':prefix');
       if (null !== $prefix) {
         $this->builder->prefix($this->builder->lookupPrefix($prefix));

--- a/src/Graphite/Graph/Series.php
+++ b/src/Graphite/Graph/Series.php
@@ -198,6 +198,15 @@ class Graphite_Graph_Series {
         "metric does not have any data associated with it.");
     }
 
+    if (is_array($conf['series'])) {
+      // generate each grouped series
+      $grouped = array();
+      foreach ($conf['series'] as $series) {
+        $grouped[] = self::generate($series);
+      }
+      $conf['series'] = implode(',',$grouped);
+    }
+
     // find functions named in the conf data
     $funcs = array();
     foreach ($conf as $key => $args) {

--- a/src/Graphite/GraphBuilder.php
+++ b/src/Graphite/GraphBuilder.php
@@ -291,6 +291,27 @@ class Graphite_GraphBuilder {
 
 
   /**
+   * Add default values to the provided series options.
+   *
+   * @param string $name Series name
+   * @param array $opts Series options
+   * @return array Series options merged with default values
+   */
+  public function addSeriesDefaults ($name, $opts) {
+    return array_merge(
+        array(
+            // default alias is prettied up version of name
+            'alias'   => ucwords(strtr($name, '-_.', ' ')),
+
+            // default series is prefixed name
+            'series'  => "{$this->currentPrefix()}{$name}",
+          ),
+        $opts
+      );
+  } //end addSeriesDefaults
+
+
+  /**
    * Add a data series to the graph.
    *
    * @param string $name Name of data series to graph
@@ -299,15 +320,7 @@ class Graphite_GraphBuilder {
    */
   public function series ($name, $opts=array()) {
     $this->storeMeta('series', $name, $opts);
-    $defaults = array(
-      // default alias is prettied up version of name
-      'alias'   => ucwords(strtr($name, '-_.', ' ')),
-
-      // default series is prefixed name
-      'series'  => "{$this->currentPrefix()}{$name}",
-    );
-    $this->targets[] = array_merge($defaults, $opts);
-
+    $this->targets[] = $this->addSeriesDefaults($name, $opts);
     return $this;
   } //end series
 

--- a/tests/Graphite/GraphBuilderTest.php
+++ b/tests/Graphite/GraphBuilderTest.php
@@ -198,6 +198,18 @@ class Graphite_GraphBuilderTest extends PHPUnit_Framework_TestCase {
   }
 
   /**
+   * Given: ini config using :series
+   * Expect: grouped targets
+   */
+  public function test_group_series () {
+    $g = Graphite_GraphBuilder::builder()
+        ->prefix('com.example.foo')
+        ->ini($this->iniPath('test_group_series.ini'));
+    $this->assertEquals('target=cactiStyle(group(alias(color(scale(derivative(com.example.foo.munin.cpu.irq),0.001),\'red\'),\'IRQ\'),alias(color(scale(derivative(com.example.foo.munin.cpu.softirq),0.001),\'yellow\'),\'Batched+IRQ\')))&target=alias(color(drawAsInfinite(puppet.time.total),\'blue\'),\'Puppet+Run\')', (string) $g);
+  }
+
+
+  /**
    * Get the path to an ini file.
    * @param string $file File name
    * @return string Path to file

--- a/tests/Graphite/test_group_series.ini
+++ b/tests/Graphite/test_group_series.ini
@@ -1,0 +1,36 @@
+[cpu]
+:is = "prefix"
+prefix = "munin.cpu"
+
+[irq]
+:is = "abstract"
+:prefix = cpu
+derivative = true
+scale = 0.001
+color = red
+alias = IRQ
+
+[softirq]
+:is = "abstract"
+:prefix = cpu
+derivative = true
+scale = 0.001
+color = yellow
+alias = Batched IRQ
+
+[group]
+:series = "irq, softirq"
+group = true
+cactiStyle = true
+alias = false
+
+[puppet]
+:is = "prefix"
+prefix = "^puppet.time"
+
+[puppet_ran]
+:prefix = puppet
+metric = total
+color = blue
+alias = Puppet Run
+inf = 1


### PR DESCRIPTION
Added ability to construct a series that uses the expanded versions of
multiple other series as it's basis. The derived series will have a comma
separated series list as it's starting point. Additional functions such as
`group()` can then be applied to the list of series.

By default the source series will be graphed as well as the derived series. If
you don't want to render the source series they can be marked `:is
= abstract`.

Syntax:

```
[one]
:is = abstract

[two]
:is = abstract

[group]
:series[] = one
:series[] = two
; or :series = "one, two"
```
